### PR TITLE
# resolver.rb additional_requirements dup

### DIFF
--- a/lib/cocoapods-bin/native/resolver.rb
+++ b/lib/cocoapods-bin/native/resolver.rb
@@ -1,14 +1,13 @@
-require 'parallel'
-require 'cocoapods'
-require 'cocoapods-bin/native/podfile'
-require 'cocoapods-bin/native/sources_manager'
-require 'cocoapods-bin/native/installation_options'
-require 'cocoapods-bin/gem_version'
+require "parallel"
+require "cocoapods"
+require "cocoapods-bin/native/podfile"
+require "cocoapods-bin/native/sources_manager"
+require "cocoapods-bin/native/installation_options"
+require "cocoapods-bin/gem_version"
 
 module Pod
   class Resolver
-
-    if Pod.match_version?('~> 1.6')
+    if Pod.match_version?("~> 1.6")
       # 其实不用到 resolver_specs_by_target 再改 spec
       # 在这个方法里面，通过修改 dependency 的 source 应该也可以
       # 就是有一点，如果改了之后，对应的 source 没有符合 dependency 的版本
@@ -19,29 +18,29 @@ module Pod
         sources_manager = Config.instance.sources_manager
         if dependency && dependency.podspec_repo
           sources_manager.aggregate_for_dependency(dependency)
-        # 采用 lock 中的 source ，会导致插件对 source 的先后调整失效
-        # elsif (locked_vertex = @locked_dependencies.vertex_named(dependency.name)) && (locked_dependency = locked_vertex.payload) && locked_dependency.podspec_repo
-        #   sources_manager.aggregate_for_dependency(locked_dependency)
+          # 采用 lock 中的 source ，会导致插件对 source 的先后调整失效
+          # elsif (locked_vertex = @locked_dependencies.vertex_named(dependency.name)) && (locked_dependency = locked_vertex.payload) && locked_dependency.podspec_repo
+          #   sources_manager.aggregate_for_dependency(locked_dependency)
         else
           @aggregate ||= Source::Aggregate.new(sources)
         end
       end
     end
 
-
-    if Pod.match_version?('~> 1.4') 
-      def specifications_for_dependency(dependency, additional_requirements = [])
+    if Pod.match_version?("~> 1.4")
+      def specifications_for_dependency(dependency, additional_requirements_frozen = [])
+        additional_requirements = additional_requirements_frozen.dup
         additional_requirements.compact!
         requirement = Requirement.new(dependency.requirement.as_list + additional_requirements.flat_map(&:as_list))
-        requirement = Requirement.new(dependency.requirement.as_list.map { |r| r + '.a' } + additional_requirements.flat_map(&:as_list)) if podfile.allow_prerelease? && !requirement.prerelease?
+        requirement = Requirement.new(dependency.requirement.as_list.map { |r| r + ".a" } + additional_requirements.flat_map(&:as_list)) if podfile.allow_prerelease? && !requirement.prerelease?
 
-        if Pod.match_version?('~> 1.7') 
+        if Pod.match_version?("~> 1.7")
           options = podfile.installation_options
         else
           options = installation_options
         end
 
-        if Pod.match_version?('~> 1.8') 
+        if Pod.match_version?("~> 1.8")
           specifications = find_cached_set(dependency).
             all_specifications(options.warn_for_multiple_pod_sources, requirement)
         else
@@ -55,13 +54,14 @@ module Pod
       end
     end
 
-    if Pod.match_version?('~> 1.6') 
+    if Pod.match_version?("~> 1.6")
       alias_method :old_valid_possibility_version_for_root_name?, :valid_possibility_version_for_root_name?
+
       def valid_possibility_version_for_root_name?(requirement, activated, spec)
         return true if podfile.allow_prerelease?
         old_valid_possibility_version_for_root_name?(requirement, activated, spec)
       end
-    elsif Pod.match_version?('~> 1.4')
+    elsif Pod.match_version?("~> 1.4")
       def requirement_satisfied_by?(requirement, activated, spec)
         version = spec.version
         return false unless requirement.requirement.satisfied_by?(version)
@@ -75,10 +75,10 @@ module Pod
 
     # >= 1.4.0 才有 resolver_specs_by_target 以及 ResolverSpecification
     # >= 1.5.0 ResolverSpecification 才有 source，供 install 或者其他操作时，输入 source 变更
-    # 
-    if Pod.match_version?('~> 1.4') 
+    #
+    if Pod.match_version?("~> 1.4")
       old_resolver_specs_by_target = instance_method(:resolver_specs_by_target)
-      define_method(:resolver_specs_by_target) do 
+      define_method(:resolver_specs_by_target) do
         specs_by_target = old_resolver_specs_by_target.bind(self).call()
 
         sources_manager = Config.instance.sources_manager
@@ -88,7 +88,7 @@ module Pod
         specs_by_target.each do |target, rspecs|
           # use_binaries 并且 use_source_pods 不包含
           use_binary_rspecs = if podfile.use_binaries? || podfile.use_binaries_selector
-                                rspecs.select do |rspec| 
+                                rspecs.select do |rspec|
                                   ([rspec.name, rspec.root.name] & use_source_pods).empty? &&
                                   (podfile.use_binaries_selector.nil? || podfile.use_binaries_selector.call(rspec.spec))
                                 end
@@ -96,7 +96,7 @@ module Pod
                                 []
                               end
 
-          # Parallel.map(rspecs, in_threads: 8) do |rspec| 
+          # Parallel.map(rspecs, in_threads: 8) do |rspec|
           specs_by_target[target] = rspecs.map do |rspec|
             # 含有 subspecs 的组件暂不处理
             # next rspec if rspec.spec.subspec? || rspec.spec.subspecs.any?
@@ -104,17 +104,17 @@ module Pod
             # developments 组件采用默认输入的 spec (development pods 的 source 为 nil)
             next rspec unless rspec.spec.respond_to?(:spec_source) && rspec.spec.spec_source
 
-            # 采用二进制依赖并且不为开发组件 
+            # 采用二进制依赖并且不为开发组件
             use_binary = use_binary_rspecs.include?(rspec)
-            source = use_binary ? sources_manager.binary_source : sources_manager.code_source 
+            source = use_binary ? sources_manager.binary_source : sources_manager.code_source
 
             spec_version = rspec.spec.version
 
-            UI.message "- 开始处理 #{rspec.spec.name} #{spec_version} 组件." 
+            UI.message "- 开始处理 #{rspec.spec.name} #{spec_version} 组件."
 
             begin
               # 从新 source 中获取 spec
-              specification = source.specification(rspec.root.name, spec_version)   
+              specification = source.specification(rspec.root.name, spec_version)
 
               # 组件是 subspec
               specification = specification.subspec_by_name(rspec.name, false, true) if rspec.spec.subspec?
@@ -122,31 +122,31 @@ module Pod
               # 造成 subspec_by_name 返回 nil，这个是正常现象
               next unless specification
 
-              if Pod.match_version?('~> 1.7')
+              if Pod.match_version?("~> 1.7")
                 used_by_only = rspec.used_by_non_library_targets_only
               else
                 used_by_only = rspec.used_by_tests_only
               end
               # used_by_only = rspec.respond_to?(:used_by_tests_only) ? rspec.used_by_tests_only : rspec.used_by_non_library_targets_only
               # 组装新的 rspec ，替换原 rspec
-              rspec = if Pod.match_version?('~> 1.4.0')
+              rspec = if Pod.match_version?("~> 1.4.0")
                         ResolverSpecification.new(specification, used_by_only)
                       else
                         ResolverSpecification.new(specification, used_by_only, source)
                       end
               rspec
-            rescue Pod::StandardError => error  
+            rescue Pod::StandardError => error
               # 没有从新的 source 找到对应版本组件，直接返回原 rspec
               missing_binary_specs << rspec.spec if use_binary
               rspec
             end
 
-            rspec 
+            rspec
           end.compact
         end
 
-        missing_binary_specs.uniq.each do |spec| 
-          UI.message "【#{spec.name} | #{spec.version}】组件无对应二进制版本 , 将采用源码依赖." 
+        missing_binary_specs.uniq.each do |spec|
+          UI.message "【#{spec.name} | #{spec.version}】组件无对应二进制版本 , 将采用源码依赖."
         end if missing_binary_specs.any?
 
         specs_by_target
@@ -154,7 +154,7 @@ module Pod
     end
   end
 
-  if Pod.match_version?('~> 1.4.0')
+  if Pod.match_version?("~> 1.4.0")
     # 1.4.0 没有 spec_source
     class Specification
       class Set
@@ -165,10 +165,10 @@ module Pod
           define_method(:initialize) do |name, version, source|
             old_initialize.bind(self).call(name, version, source)
 
-            @spec_source = source 
+            @spec_source = source
           end
 
-          def respond_to?(method, include_all = false) 
+          def respond_to?(method, include_all = false)
             return super unless method == :spec_source
             true
           end
@@ -177,4 +177,3 @@ module Pod
     end
   end
 end
-


### PR DESCRIPTION
在cocoapods1.8.3中，specifications_for_dependency 参数中的additional_requirements是frozen的。回报FrozenError 。本次提交对这个参数做了dup操作。

主要改变在31，32行。

其他的改动都是VSCode自动吧单引号换成双引号了，懒得改了(>^ω^<)