### PR TITLE
解决Archive 不能指定podspec的问题

### DIFF
--- a/lib/cocoapods-bin/command/bin/archive.rb
+++ b/lib/cocoapods-bin/command/bin/archive.rb
@@ -36,7 +36,7 @@ module Pod
           @sources = argv.option('sources') || []
           @platform = Platform.new(:ios)
           super
-
+          @podspec = argv.shift_argument
           @additional_args = argv.remainder!
         end
 


### PR DESCRIPTION
一个文件夹下，有两个 podspec 文件
使用 `pod bin archive [NAME.podspec]` 指定 podspec 不能生效